### PR TITLE
add the most basic zombie tree ever, add CSS/JS minifying, add nicer looking error pages

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -15,6 +15,7 @@ django-user-agents = "*"
 wagtail = "*"
 gunicorn = "*"
 django-admin-view-permission = "*"
+django-compressor = "*"
 
 [dev-packages]
 

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "e69d3713ff14477064facd62dd6663cf72f09b8c2baa18a166f2b45ba07c3e03"
+            "sha256": "8240cd91edf1edc158e3e8dcb32342b2b4b1e27d6f091cd9b6b73ecffbe5a77f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -118,6 +118,21 @@
             ],
             "index": "pypi",
             "version": "==1.6"
+        },
+        "django-appconf": {
+            "hashes": [
+                "sha256:6a4d9aea683b4c224d97ab8ee11ad2d29a37072c0c6c509896dd9857466fb261",
+                "sha256:ddab987d14b26731352c01ee69c090a4ebfc9141ed223bef039d79587f22acd9"
+            ],
+            "version": "==1.0.2"
+        },
+        "django-compressor": {
+            "hashes": [
+                "sha256:7732676cfb9d58498dfb522b036f75f3f253f72ea1345ac036434fdc418c2e57",
+                "sha256:9616570e5b08e92fa9eadc7a1b1b49639cce07ef392fc27c74230ab08075b30f"
+            ],
+            "index": "pypi",
+            "version": "==2.2"
         },
         "django-enumfields": {
             "hashes": [
@@ -292,12 +307,24 @@
             ],
             "version": "==2018.5"
         },
+        "rcssmin": {
+            "hashes": [
+                "sha256:ca87b695d3d7864157773a61263e5abb96006e9ff0e021eff90cbe0e1ba18270"
+            ],
+            "version": "==1.0.6"
+        },
         "requests": {
             "hashes": [
                 "sha256:63b52e3c866428a224f97cab011de738c36aec0185aa91cfacd418b5d58911d1",
                 "sha256:ec22d826a36ed72a7358ff3fe56cbd4ba69dd7a6718ffd450ff0e9df7a47ce6a"
             ],
             "version": "==2.19.1"
+        },
+        "rjsmin": {
+            "hashes": [
+                "sha256:dd9591aa73500b08b7db24367f8d32c6470021f39d5ab4e50c7c02e4401386f1"
+            ],
+            "version": "==1.0.12"
         },
         "six": {
             "hashes": [

--- a/app/admin.py
+++ b/app/admin.py
@@ -34,6 +34,11 @@ class GameAdmin(admin.ModelAdmin):
 
 @admin.register(Tag)
 class TagAdmin(admin.ModelAdmin):
+    search_fields = ('initiator__user__first_name', 'initiator__user__last_name', 'receiver__user__first_name', 'receiver__user__last_name')
+
+    def get_full_name(self, obj):
+        return obj.user.get_full_name()
+
     def has_delete_permission(self, request, obj=None):
         return False
 

--- a/app/static/stylesheets/components/_titlebar.scss
+++ b/app/static/stylesheets/components/_titlebar.scss
@@ -46,6 +46,7 @@
 #titlebar-title {
   justify-content: flex-start;
   flex: 1 1 auto;
+  border-right: 1px solid;
 
   h1 {
     font-size: 1rem;
@@ -68,6 +69,7 @@
   &:active,
   &:focus,
   &:hover {
+    color: color(sky, lighter);
     text-decoration: underline;
   }
 }

--- a/app/static/stylesheets/dashboard.scss
+++ b/app/static/stylesheets/dashboard.scss
@@ -1,0 +1,24 @@
+//// 
+/// Dashboard styling.
+////
+
+// Utilities
+@import 'base/utilities';
+@import 'base/border-radius';
+@import 'base/breakpoints';
+@import 'base/colors';
+@import 'base/shadows';
+@import 'base/spacing';
+@import 'base/z-index';
+
+// Layout and Typography Utilities
+@import 'base/layout';
+@import 'base/typography/utilities';
+
+// Components
+@import 'components/menu';
+@import 'components/sidebar';
+@import 'components/titlebar';
+
+// Site-specific pages
+@import 'site/dashboard';

--- a/app/static/stylesheets/global.scss
+++ b/app/static/stylesheets/global.scss
@@ -14,7 +14,7 @@
 // Fonts
 @import 'fonts/komu';
 
-// Layout and Typography Utilities
+// Layout & typography Utilities
 @import 'base/layout';
 @import 'base/typography/utilities';
 
@@ -25,17 +25,11 @@
 
 // Components
 @import 'components/card';
-@import 'components/countdown';
 @import 'components/form';
 @import 'components/layout';
 @import 'components/logo';
-@import 'components/menu';
-@import 'components/sidebar';
 @import 'components/text-container';
-@import 'components/titlebar';
 
 // Site-specific pages
-@import 'site/landing';
 @import 'site/signups';
-@import 'site/dashboard';
 @import 'site/mobile';

--- a/app/static/stylesheets/landing.scss
+++ b/app/static/stylesheets/landing.scss
@@ -1,0 +1,19 @@
+//// 
+/// Global styling.
+////
+
+// Utilities
+@import 'base/utilities';
+@import 'base/border-radius';
+@import 'base/breakpoints';
+@import 'base/colors';
+@import 'base/shadows';
+@import 'base/spacing';
+@import 'base/z-index';
+@import 'base/typography/utilities';
+
+// Components
+@import 'components/countdown';
+
+// Site-specific pages
+@import 'site/landing';

--- a/app/static/stylesheets/site/_dashboard.scss
+++ b/app/static/stylesheets/site/_dashboard.scss
@@ -5,7 +5,7 @@
 
 
 .s-dashboard__index {
-  grid-template-columns: minmax(auto, 12.5rem) 2fr 2fr;
+  grid-template-columns: 1fr 2fr 2fr;
 }
 
 .s-dashboard__game-info,

--- a/app/static/stylesheets/site/_landing.scss
+++ b/app/static/stylesheets/site/_landing.scss
@@ -2,7 +2,7 @@
   height: auto;
   display: block;
   position: relative;
-  background-color: color(ink);
+  background: color(ink);
   color: color(sky);
   
   .ui-layout__item {

--- a/app/static/stylesheets/site/_mobile.scss
+++ b/app/static/stylesheets/site/_mobile.scss
@@ -3,7 +3,7 @@
   height: 100%;
   display: block;
   position: relative;
-  background-color: color(ink);
+  background: rgba(color(ink), 0.95);
   color: color(sky);
   text-align: center;
 }

--- a/app/templates/jinja2/403.html
+++ b/app/templates/jinja2/403.html
@@ -1,0 +1,21 @@
+{% from "components/card.html" import card %}
+{% extends "base.html" %}
+
+{% block content %}
+
+<main class="ui-layout">
+  <section class="container ui-layout__item">
+    <div class="row">
+      <div class="col-lg-6 mx-auto text-center">
+        {% call card('You are not allowed to view this page.') %}
+          <p>You do not have the proper permissions to view this page.</p>
+          <div class="ui-form-group">
+            <a class="btn btn-primary" href="{{ url('index') }}">Return to Site</a>
+          </div>
+        {% endcall %}
+      </div>
+    </div>
+  </div>
+</main>
+
+{% endblock %}

--- a/app/templates/jinja2/404.html
+++ b/app/templates/jinja2/404.html
@@ -1,0 +1,21 @@
+{% from "components/card.html" import card %}
+{% extends "base.html" %}
+
+{% block content %}
+
+<main class="ui-layout">
+  <section class="container ui-layout__item">
+    <div class="row">
+      <div class="col-lg-6 mx-auto text-center">
+        {% call card('Oops! We can't find the page you're looking for.') %}
+          <p>Unfortunately, we couldn't find the page you were looking for. Would you like to try again from the beginning, and go back to the main site?</p>
+          <div class="ui-form-group">
+            <a class="btn btn-primary" href="{{ url('index') }}">Return to Site</a>
+          </div>
+        {% endcall %}
+      </div>
+    </div>
+  </section>
+</main>
+
+{% endblock %}

--- a/app/templates/jinja2/500.html
+++ b/app/templates/jinja2/500.html
@@ -1,0 +1,22 @@
+{% from "components/card.html" import card %}
+{% extends "base.html" %}
+
+{% block content %}
+
+<main class="ui-layout">
+  <section class="container ui-layout__item">
+    <div class="row">
+      <div class="col-lg-6 mx-auto text-center">
+        {% call card('Seems like we hit a snag.') %}
+          <p>It seems that we're having some troubles with our server. Sorry about that! :( We'll be fixing this as soon as possible.</p>
+          <p>For now, how about you return to the main site?</p>
+          <div class="ui-form-group">
+            <a class="btn btn-primary" href="{{ url('index') }}">Return to Site</a>
+          </div>
+        {% endcall %}
+      </div>
+    </div>
+  </section>
+</main>
+
+{% endblock %}

--- a/app/templates/jinja2/base.html
+++ b/app/templates/jinja2/base.html
@@ -8,8 +8,10 @@
 
     <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.1.1/css/bootstrap.min.css" integrity="sha384-WskhaSGFgHYWDcbwN70/dfYBj47jz9qbsMId/iRN3ewGhXQFZCSftd1LZCfmhktB" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css" integrity="sha256-BJ/G+e+y7bQdrYkS2RBTyNfBHpA9IuGaPmf9htub5MQ=" crossorigin="anonymous">
-    
-    <link href="{% sass_src 'stylesheets/global.scss' %}" rel="stylesheet" type="text/css">
+
+    {% compress css %}
+      <link href="{% sass_src 'stylesheets/global.scss' %}" rel="stylesheet" type="text/css">
+    {% endcompress %}
     {% block styles %}{% endblock %}
   </head>
   

--- a/app/templates/jinja2/dashboard/base.html
+++ b/app/templates/jinja2/dashboard/base.html
@@ -1,5 +1,12 @@
 {% extends "base.html" %}
 
+{% block styles %}
+  {% compress css %}
+    <link href="{% sass_src 'stylesheets/dashboard.scss' %}" rel="stylesheet" type="text/css">
+  {% endcompress %}
+  {% block additional_styles %}{% endblock %}
+{% endblock %}
+
 {% block content %}
 <header class="ui-titlebar">
   <div class="ui-titlebar__section" id="titlebar-logo">
@@ -30,7 +37,7 @@
     <nav class="ui-menu">
       <a class="ui-menu__header-link" href="#player-actions" data-target="#player-actions" data-toggle="collapse" aria-expanded="{% if "/moderator" not in request.path %}true{% else %}false{% endif %}">
         <header class="ui-menu__header">
-          <h1 class="ui-menu__title">Game Actions</h1>
+          <h1 class="ui-menu__title">Player Actions</h1>
           <div class="ui-menu__icon">
             <span aria-hidden="true" class="oi oi-plus"></span>
             <span aria-hidden="true" class="oi oi-minus"></span>
@@ -38,13 +45,13 @@
         </header>
       </a>
       <ul class="ui-menu__section collapse{% if "/moderator" not in request.path %} show{% endif %}" data-parent="#side-nav" id="player-actions">
-        <li><a href="{{ url('player_info') }}">Game Dashboard</a></li>
-        <li><a href="/dashboard/game-info/">Info & News</a></li>
-        <li><a href="{{ static('files/hvz-rules-v1.3.pdf') }}">Rules</a></li>
+        <li><a href="{{ url('player_info') }}">Player Dashboard</a></li>
+        <li><a href="/dashboard/game-info/">Game Info & News</a></li>
         <li><a href="{{ url('player_list') }}">Player List</a></li>
         {% if (player is defined and player is not none and not player.is_human) or user.is_moderator %}
-          <li><a href="#">Zombie Tree</a></li>
+        <li><a href="{{ url('zombie_tree') }}">Zombie Tree</a></li>
         {% endif %}
+        <li><a href="{{ static('files/hvz-rules-v1.3.pdf') }}">Rules</a></li>
       </ul>
     </nav>
   {% endif %}

--- a/app/templates/jinja2/dashboard/index.html
+++ b/app/templates/jinja2/dashboard/index.html
@@ -11,8 +11,8 @@
 <div class="ui-grid">
   <div class="ui-text-container">
     {% call card('Welcome to the website!', class='text-left') %}
-      <p>Since this is a newly built website, we hope you'll be patient with us as we work to polish it and make it awesome when the game starts.</p>
-      <p>For now, if you don't see anything else, just sit tight and wait for the game to start, as all the fun stuff will be out and ready for you to play with when it starts!</p>
+      <p>Since this is a newly built website, we hope you'll be patient with us as we work to polish it and make it awesome throughout this term's game.</p>
+      <p>If you'd like to report some bugs or give us general feedback on the website, contact the mods at <a href="mailto:uwhumansvszombies@gmail.com">uwhumansvszombies@gmail.com</a> so we can fix anything that goes wrong as soon as possible.</p>
       <p>Thank you! :)</p>
     {% endcall %}
   </div>

--- a/app/templates/jinja2/dashboard/player_list.html
+++ b/app/templates/jinja2/dashboard/player_list.html
@@ -9,24 +9,26 @@
 {% block pagesubtitle %}View Player List{% endblock %}
 
 {% block subcontent %}
-  {% call card('Player List') %}
-  <table class="table table-striped">
-    <thead>
-      <tr>
-        <th scope="col">Name</th>
-        <th scope="col">Email</th>
-        <th scope="col">Role</th>
-      </tr>
-    </thead>
-    <tbody>
-      {% for p in players %}
-      <tr>
-        <td scope="col">{{ p.user.get_full_name() }}</td>
-        <td scope="col">{{ p.user.email }}</td>
-        <td scope="col">{% if player.is_human and not p.is_spectator %}Player{% else %}{{ p.role }}{% endif %}</td>
-      </tr>
-      {% endfor %}
-    </tbody>
-  </table>
-  {% endcall %}
+
+{% call card('Player List') %}
+<table class="table table-striped">
+  <thead>
+    <tr>
+      <th scope="col">Name</th>
+      <th scope="col">Email</th>
+      <th scope="col">Role</th>
+    </tr>
+  </thead>
+  <tbody>
+    {% for p in players %}
+    <tr>
+      <td scope="col">{{ p.user.get_full_name() }}</td>
+      <td scope="col">{{ p.user.email }}</td>
+      <td scope="col">{% if player.is_human and not p.is_spectator %}Player{% else %}{{ p.role }}{% endif %}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endcall %}
+
 {% endblock %}

--- a/app/templates/jinja2/dashboard/settings.html
+++ b/app/templates/jinja2/dashboard/settings.html
@@ -1,0 +1,14 @@
+{% from "components/card.html" import card %}
+{% extends "dashboard/base.html" %}
+
+{% block title %}Dashboard - Settings{% endblock %}
+
+{% block pagetitle %}Dashboard - Settings{% endblock %}
+{% block pagesubtitle %}Website Settings{% endblock %}
+
+{% block subcontent %}
+<div class="ui-grid">
+  {% call card('Notifications') %}
+  {% endcall %}
+</div>
+{% endblock %}

--- a/app/templates/jinja2/dashboard/zombie_tree.html
+++ b/app/templates/jinja2/dashboard/zombie_tree.html
@@ -1,0 +1,47 @@
+{% from "components/card.html" import card %}
+{% extends "dashboard/base.html" %}
+
+{% block title %}Dashboard &mdash; Zombie Tree{% endblock %}
+
+{% block additional_styles %}
+  <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis.min.css" integrity="sha256-iq5ygGJ7021Pi7H5S+QAUXCPUfaBzfqeplbg/KlEssg=" crossorigin="anonymous">
+{% endblock %}
+
+{% block pagetitle %}
+  {% if game.is_running %}{{ game.name }} &mdash; {% endif %}Game Information
+{% endblock %}
+{% block pagesubtitle %}View Zombie Tree{% endblock %}
+
+{% block subcontent %}
+
+<div id="zombie-tree"></div>
+
+{% endblock %}
+
+{% block scripts %}
+  <script src="https://cdnjs.cloudflare.com/ajax/libs/vis/4.21.0/vis.min.js" integrity="sha256-JuQeAGbk9rG/EoRMixuy5X8syzICcvB0dj3KindZkY0=" crossorigin="anonymous"></script>
+  <script>
+    var container = document.getElementById('zombie-tree');
+
+    var data = {
+      nodes: {{ nodes|safe }},
+      edges: {{ edges|safe }},
+    };
+
+    var options = {
+      nodes: {
+        shape: 'dot',
+        size: 20,
+        font: {
+          size: 16,
+          color: '#000',
+        },
+        borderWidth: 1
+      },
+      edges: {
+        width: 2
+      }
+    };
+    network = new vis.Network(container, data, options);
+  </script>
+{% endblock %}

--- a/app/templates/jinja2/index.html
+++ b/app/templates/jinja2/index.html
@@ -2,6 +2,12 @@
 
 {% block title %}Index{% endblock %}
 
+{% block styles %}
+  {% compress css %}
+    <link href="{% sass_src 'stylesheets/landing.scss' %}" rel="stylesheet" type="text/css">
+  {% endcompress %}
+{% endblock %}
+
 {% block content %}
 <header id="landing-nav">
   <a href="/" class="sitelogo">{{ svg('site-logo-dark') }}</a>

--- a/app/templates/jinja2/mobile/base.html
+++ b/app/templates/jinja2/mobile/base.html
@@ -3,12 +3,19 @@
 {% block content %}
 <header class="navbar navbar-expand-lg navbar-dark ui-titlebar--mobile">
   <a class="navbar-brand text-center" href="/">{{ svg('site-logo-dark') }}</a>
-  <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
+  <button onclick="$('#navbar').collapse('toggle')" class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>
-  <nav class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="navbar-nav mr-auto">
-      {% block navigation %}{% endblock %}
+  <nav class="justify-content-end collapse navbar-collapse" id="navbar">
+    <ul class="navbar-nav">
+      {% if user.is_authenticated %}
+        <li class="nav-item active"><a class="nav-link" href="{{ url('player_info') }}">Player Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="/dashboard/game-info/">Game Info</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ static('files/hvz-rules-v1.3.pdf') }}">Rules</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url('logout') }}">Logout</a></li>
+      {% else %}
+        <li class="nav-item"><a class="nav-link" href="{{ url('login') }}">Login</a></li>
+      {% endif %}
     </ul>
   </nav>
 </header>

--- a/app/templates/jinja2/mobile/dashboard/index.html
+++ b/app/templates/jinja2/mobile/dashboard/index.html
@@ -1,0 +1,16 @@
+{% from "components/card.html" import card %}
+{% extends "mobile/base.html" %}
+
+{% block title %}Dashboard{% endblock %}
+
+{% block subcontent %}
+
+<div class="ui-grid">
+  {% call card('Welcome to the website!', class='text-left') %}
+    <p>Since this is a newly built website, we hope you'll be patient with us as we work to polish it and make it awesome when the game starts.</p>
+    <p>For now, if you don't see anything else, just sit tight and wait for the game to start, as all the fun stuff will be out and ready for you to play with when it starts!</p>
+    <p>Thank you! :)</p>
+  {% endcall %}
+</div>
+
+{% endblock %}

--- a/app/templates/jinja2/mobile/dashboard/player.html
+++ b/app/templates/jinja2/mobile/dashboard/player.html
@@ -3,13 +3,6 @@
 
 {% block title %}UW HvZ &mdash; Player Dashboard{% endblock %}
 
-{% block navigation %}
-  <li class="nav-item active"><a class="nav-link" href="{{ url('player_info') }}">Player Dashboard</a></li>
-  <li class="nav-item"><a class="nav-link" href="/dashboard/game-info/">Game Info</a></li>
-  <li class="nav-item"><a class="nav-link" href="{{ static('files/hvz-rules-v1.3.pdf') }}">Rules</a></li>
-  <li class="nav-item"><a class="nav-link" href="{{ url('logout') }}">Logout</a></li>
-{% endblock %}
-
 {% block subcontent %}
 <div class="ui-grid">
   <div class="ui-grid s-mobile-dashboard__player-info">

--- a/app/templates/jinja2/mobile/index.html
+++ b/app/templates/jinja2/mobile/index.html
@@ -4,13 +4,19 @@
 
 {% block content %}
 <header class="navbar navbar-expand-lg navbar-dark ui-titlebar--mobile">
-  <a class="navbar-brand text-center" href="/">{{ svg('site-logo-dark') }}</a>
+  <a class="navbar-brand" href="/">{{ svg('site-logo-dark') }}</a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarSupportedContent" aria-controls="navbarSupportedContent" aria-expanded="false" aria-label="Toggle navigation">
-    <span class="navbar-toggler-icon"></span>
+    <span class="navbar-toggler-icon" aria-hidden="true"></span>
   </button>
-  <nav class="collapse navbar-collapse" id="navbarSupportedContent">
-    <ul class="navbar-nav mr-auto">
-      <li class="nav-item"><a class="nav-link" href="{{ url('login') }}">Login</a></li>
+
+  <nav class="justify-content-end collapse navbar-collapse" id="navbarSupportedContent">
+    <ul class="navbar-nav">
+      {% if user.is_authenticated %}
+        <li class="nav-item"><a class="nav-link" href="{{ url('player_info') }}">Player Dashboard</a></li>
+        <li class="nav-item"><a class="nav-link" href="{{ url('logout') }}">Logout</a></li>
+      {% else %}
+        <li class="nav-item"><a class="nav-link" href="{{ url('login') }}">Login</a></li>
+      {% endif %}
     </ul>
   </nav>
 </header>
@@ -20,7 +26,12 @@
     <div id="landing-logo">
       {{ svg('club-logo') }}
       <div class="ui-form-group pt-2 text-center">
-        <a class="btn btn-lg btn-primary" href="{{ url('login') }}">Login</a>
+        {% if user.is_authenticated %}
+          <a class="btn btn-lg btn-primary d-block" href="{{ url('player_info') }}">Player Dashboard</a>
+          <a class="btn btn-lg btn-outline-light mt-3 d-block" href="{{ url('logout') }}">Logout</a>
+        {% else %}
+          <a class="btn btn-lg btn-primary" href="{{ url('login') }}">Login</a>
+        {% endif %}
       </div>
     </div>
   </section>

--- a/app/urls.py
+++ b/app/urls.py
@@ -15,6 +15,7 @@ urlpatterns = [
     path("dashboard/report-tag", views.ReportTagView.as_view(), name='report_tag'),
     path("dashboard/player", views.PlayerInfoView.as_view(), name='player_info'),
     path("dashboard/player-list", views.PlayerListView.as_view(), name='player_list'),
+    path("dashboard/zombie-tree", views.ZombieTreeView.as_view(), name='zombie_tree'),
     path("dashboard/game-signup", views.GameSignupView.as_view(), name='game_signup'),
     path("signup/<uuid:signup_invite>", views.signup, name='signup'),
     path("dashboard/moderator/generate-supply-codes", views.GenerateSupplyCodesView.as_view(),

--- a/app/views/views.py
+++ b/app/views/views.py
@@ -15,7 +15,7 @@ class IndexView(MobileSupportedView):
 @method_decorator(login_required, name='dispatch')
 class DashboardView(MobileSupportedView):
     desktop_template = "dashboard/index.html"
-    mobile_template = "dashboard/index.html"
+    mobile_template = "mobile/dashboard/index.html"
 
     def get(self, request):
         if game_exists():

--- a/uwhvz/settings/common.py
+++ b/uwhvz/settings/common.py
@@ -21,6 +21,7 @@ INSTALLED_APPS = [
     'django.contrib.messages',
     'django.contrib.staticfiles',
     'sass_processor',
+    'compressor',
     'svg',
     'django_user_agents',
     'wagtail.contrib.forms',
@@ -65,6 +66,7 @@ TEMPLATES = [
                 'wagtail.core.jinja2tags.core',
                 'wagtail.admin.jinja2tags.userbar',
                 'wagtail.images.jinja2tags.images',
+                'compressor.contrib.jinja2ext.CompressorExtension',
             ],
             'context_processors': [
                 'django.template.context_processors.debug',
@@ -133,6 +135,7 @@ STATICFILES_FINDERS = [
     'django.contrib.staticfiles.finders.FileSystemFinder',
     'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'sass_processor.finders.CssFinder',
+    'compressor.finders.CompressorFinder',
 ]
 
 WAGTAIL_SITE_NAME = 'UW Humans vs Zombies'

--- a/uwhvz/settings/development.py
+++ b/uwhvz/settings/development.py
@@ -6,6 +6,8 @@ SECRET_KEY = '6e4#bj2ea@i)f*xj4ht6rrthq@f3vw9(v8az+9==pf+3ys8pb!'
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True
 
+COMPRESS_OFFLINE = True
+
 ALLOWED_HOSTS = ['*']
 
 SITE_URL = 'http://127.0.0.1:8000'

--- a/uwhvz/settings/production.py
+++ b/uwhvz/settings/production.py
@@ -27,20 +27,7 @@ DATABASES = {
     }
 }
 
-AUTH_PASSWORD_VALIDATORS += [
-    {
-        'NAME': 'django.contrib.auth.password_validation.UserAttributeSimilarityValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.MinimumLengthValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.CommonPasswordValidator',
-    },
-    {
-        'NAME': 'django.contrib.auth.password_validation.NumericPasswordValidator',
-    },
-]
+COMPRESS_OFFLINE = True
 
 CACHES = {
     'default': {


### PR DESCRIPTION
# Changelist
## Features
- add zombie tree (#53)
## Frontend
- add nicer-looking 404/403/500 error pages
- clean up titlebar
- separate CSS depending on which type of page is loaded (e.g. dashboard, landing)
## Backend
- add CSS/JS minification
- add `try/except`s for any attempts to get a `Player` object attached to a `User`
- add search filters for player names in `TagAdmin`
- configure `django-compressor`